### PR TITLE
Add scenario chat assistant (Act II)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts_build_fe.env
+
+# local python env
+.venv/
+__pycache__/

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ Reads EM-DAT parquet files directly and serves three endpoints:
   /api/emdat-event-markdown/{event_key}
 """
 
+import json
 import math
 import os
 
@@ -14,6 +15,7 @@ import pandas as pd
 from fastapi import FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
+from pydantic import BaseModel
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -22,6 +24,27 @@ PARQUET_DIR = os.environ.get(
     "PARQUET_DIR",
     os.path.join(os.path.dirname(__file__), "data"),
 )
+
+SCENARIOS_DIR = os.environ.get(
+    "SCENARIOS_DIR",
+    os.path.join(os.path.dirname(__file__), "data", "scenarios"),
+)
+
+# Scenario chat assistant (Act II explanatory LLM)
+# Provider: "anthropic", "ollama", or "auto" (anthropic if credentials are set,
+# otherwise a local Ollama server — useful for offline/keyless local dev).
+LLM_PROVIDER = os.environ.get("SCENARIO_LLM_PROVIDER", "auto")
+CHAT_MODEL = os.environ.get("SCENARIO_CHAT_MODEL", "claude-opus-4-8")
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "llama3.2:3b")
+
+
+def _resolve_provider() -> str:
+    if LLM_PROVIDER != "auto":
+        return LLM_PROVIDER
+    if os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_AUTH_TOKEN"):
+        return "anthropic"
+    return "ollama"
 
 app = FastAPI(title="CRMA Dashboard API")
 
@@ -252,6 +275,239 @@ async def mdx_media(path: str):
 
 
 # ---------------------------------------------------------------------------
+# Scenario simulation: definitions + LLM chat assistant
+# ---------------------------------------------------------------------------
+_scenarios: dict[str, dict] = {}
+
+
+def _load_scenarios() -> dict[str, dict]:
+    if not _scenarios and os.path.isdir(SCENARIOS_DIR):
+        import glob
+
+        for path in glob.glob(os.path.join(SCENARIOS_DIR, "*.json")):
+            try:
+                with open(path) as f:
+                    sc = json.load(f)
+                _scenarios[sc["event_id"]] = sc
+            except (json.JSONDecodeError, KeyError):
+                continue
+    return _scenarios
+
+
+# Fields that reveal the historical outcome — withheld until debrief
+_OUTCOME_FIELDS = ("peak", "debrief", "counterfactual")
+
+
+@app.get("/api/scenarios")
+async def list_scenarios():
+    items = [
+        {
+            "event_id": sc["event_id"],
+            "title": sc.get("title", sc["event_id"]),
+            "hazard": sc.get("hazard"),
+            "country": sc.get("country"),
+            "forecastability": sc.get("forecastability"),
+        }
+        for sc in _load_scenarios().values()
+    ]
+    items.sort(key=lambda s: (s["hazard"] or "", s["country"] or ""))
+    return {"scenarios": items}
+
+
+@app.get("/api/scenarios/{event_id}")
+async def get_scenario(event_id: str, debrief: bool = Query(False)):
+    sc = _load_scenarios().get(event_id)
+    if sc is None:
+        return JSONResponse({"error": f"Unknown scenario: {event_id}"}, status_code=404)
+    if debrief:
+        return sc
+    # Forward-mode view: strip outcome fields so the UI cannot leak them
+    return {k: v for k, v in sc.items() if k not in _OUTCOME_FIELDS}
+
+
+class ChatMessage(BaseModel):
+    role: str  # "user" | "assistant"
+    content: str
+
+
+class ScenarioChatRequest(BaseModel):
+    scenario_id: str
+    round: int = 1
+    debrief: bool = False
+    message: str
+    history: list[ChatMessage] = []
+    bn_state: dict | None = None  # optional posterior snapshot from the DAG panel
+
+
+def _evidence_value_at(card: dict, cursor_date: str) -> str | None:
+    """Most recent value at or before the cursor date."""
+    values = card.get("value_by_date", {})
+    dated = sorted((d, v) for d, v in values.items() if d <= cursor_date)
+    return dated[-1][1] if dated else None
+
+
+def _build_chat_system_prompt(sc: dict, round_num: int, debrief: bool, bn_state: dict | None) -> str:
+    rounds = sc.get("rounds", [])
+    round_num = max(1, min(round_num, len(rounds)))
+    current = rounds[round_num - 1]
+    cursor = current.get("cursor_date", "")
+
+    revealed_ids: list[str] = []
+    for r in rounds[:round_num]:
+        revealed_ids.extend(r.get("reveal_evidence", []))
+    cards = {c["id"]: c for c in sc.get("evidence_cards", [])}
+
+    evidence_lines = []
+    for eid in revealed_ids:
+        card = cards.get(eid)
+        if not card:
+            continue
+        value = _evidence_value_at(card, cursor)
+        line = f"- {card.get('label', eid)} (BN node: {card.get('bn_node', '?')}, type: {card.get('evidence_type', '?')})"
+        if value:
+            line += f" — current value: {value}"
+        if card.get("teaching_note"):
+            line += f"\n  Teaching note (weave in when relevant, do not read verbatim): {card['teaching_note']}"
+        evidence_lines.append(line)
+
+    decision = sc.get("decision", {})
+    ladder = " → ".join(decision.get("ladder", []))
+
+    prompt = f"""You are the facilitation assistant for an interactive Disaster Operations Centre (DOC) simulation \
+run by ICPAC for East Africa. Participants are DOC analysts working through a historical {sc.get('hazard', '')} \
+scenario using a Bayesian Network (BN) for transparent belief updating.
+
+SCENARIO: {sc.get('title', sc.get('event_id'))}
+COUNTRY/REGION: {sc.get('country', '?')} — {sc.get('admin1', '')}
+BRIEF: {sc.get('brief_outcome_free', '')}
+
+SIMULATION TIME: the cursor is at {cursor} (round {round_num} of {len(rounds)}: "{current.get('title', '')}").
+ENGINE STATE: {current.get('engine_state', '')}
+
+EVIDENCE REVEALED SO FAR (participants can only see these):
+{chr(10).join(evidence_lines) if evidence_lines else '- none yet'}
+
+DECISION LADDER: {ladder}
+CHECKPOINT PROMPT (when participants ask about decisions): {decision.get('checkpoint_prompt', '')}
+
+EVIDENCE TYPOLOGY you teach:
+- hard evidence: directly observed, sets a BN node state with certainty
+- soft evidence: uncertain observation, enters the BN as a likelihood over node states
+- virtual evidence: indicator not modelled as a BN parent (e.g. CDI); updates the risk posterior multiplicatively (Pearl virtual evidence)
+
+YOUR ROLE:
+- Explain evidence cards, BN structure, belief updating, uncertainty, and the hard/soft/virtual distinction in plain language.
+- Be Socratic about decisions: never tell participants which DOC level to choose. Ask what the evidence and posterior support, what additional evidence would change their mind, and what no-regret actions the lead time allows.
+- Keep answers short (2-5 sentences unless asked to elaborate) and grounded in the revealed evidence only.
+- The simulation clock is at {cursor}. Treat anything after this date as unknown."""
+
+    if debrief:
+        peak = sc.get("peak", {})
+        counterfactual = sc.get("counterfactual", {})
+        prompt += f"""
+
+DEBRIEF MODE: the exercise has ended and the historical outcome may now be discussed.
+- Recorded peak: {peak.get('date', '?')} — {peak.get('description', '')}
+- Counterfactual to explore: {counterfactual.get('prompt', '')} {counterfactual.get('narrative', '')}
+Guide forensic reconstruction: which signals preceded the event, whether action came early enough, and the value of lead time."""
+    else:
+        prompt += """
+
+STRICT RULE: this is a forward-looking exercise. You know this is a historical event, but you must NOT reveal \
+the outcome, the peak date, losses, damages, or anything from after the simulation cursor. If asked, say the \
+outcome is revealed at the debrief and redirect to interpreting the current evidence."""
+
+    if bn_state:
+        prompt += f"\n\nCURRENT BN POSTERIOR SNAPSHOT (from the participant's DAG panel):\n{json.dumps(bn_state, sort_keys=True)}"
+
+    return prompt
+
+
+def _chat_anthropic(system: str, messages: list[dict]) -> tuple[dict | None, JSONResponse | None]:
+    try:
+        import anthropic
+    except ImportError:
+        return None, JSONResponse({"error": "anthropic package not installed on the API server"}, status_code=503)
+
+    try:
+        client = anthropic.Anthropic()
+        response = client.messages.create(
+            model=CHAT_MODEL,
+            max_tokens=1024,
+            system=system,
+            messages=messages,
+        )
+    except (anthropic.AuthenticationError, TypeError):
+        # TypeError: SDK raises it when no credentials are configured at all
+        return None, JSONResponse(
+            {"error": "ANTHROPIC_API_KEY is missing or invalid on the API server"},
+            status_code=503,
+        )
+    except anthropic.APIStatusError as e:
+        return None, JSONResponse({"error": f"LLM API error ({e.status_code})"}, status_code=502)
+    except anthropic.APIConnectionError:
+        return None, JSONResponse({"error": "Could not reach the LLM API"}, status_code=502)
+
+    if response.stop_reason == "refusal":
+        reply = "I can't help with that — let's get back to the scenario evidence."
+    else:
+        reply = "".join(b.text for b in response.content if b.type == "text")
+    return {"reply": reply, "model": response.model, "provider": "anthropic"}, None
+
+
+def _chat_ollama(system: str, messages: list[dict]) -> tuple[dict | None, JSONResponse | None]:
+    import httpx
+
+    payload = {
+        "model": OLLAMA_MODEL,
+        "messages": [{"role": "system", "content": system}, *messages],
+        "stream": False,
+        "options": {"num_predict": 1024},
+    }
+    try:
+        r = httpx.post(f"{OLLAMA_BASE_URL}/api/chat", json=payload, timeout=120.0)
+    except httpx.ConnectError:
+        return None, JSONResponse(
+            {"error": f"Ollama server not reachable at {OLLAMA_BASE_URL} — run `ollama serve`"},
+            status_code=503,
+        )
+    if r.status_code == 404:
+        return None, JSONResponse(
+            {"error": f"Model {OLLAMA_MODEL!r} not found in Ollama — run `ollama pull {OLLAMA_MODEL}`"},
+            status_code=503,
+        )
+    if r.status_code != 200:
+        return None, JSONResponse({"error": f"Ollama error ({r.status_code}): {r.text[:200]}"}, status_code=502)
+
+    data = r.json()
+    reply = data.get("message", {}).get("content", "")
+    return {"reply": reply, "model": OLLAMA_MODEL, "provider": "ollama"}, None
+
+
+@app.post("/api/scenario-chat")
+async def scenario_chat(req: ScenarioChatRequest):
+    sc = _load_scenarios().get(req.scenario_id)
+    if sc is None:
+        return JSONResponse({"error": f"Unknown scenario: {req.scenario_id}"}, status_code=404)
+
+    system = _build_chat_system_prompt(sc, req.round, req.debrief, req.bn_state)
+
+    messages = [
+        {"role": m.role, "content": m.content}
+        for m in req.history[-20:]  # cap history; the API is stateless
+        if m.role in ("user", "assistant") and m.content.strip()
+    ]
+    messages.append({"role": "user", "content": req.message})
+
+    provider = _resolve_provider()
+    if provider == "ollama":
+        result, error = _chat_ollama(system, messages)
+    else:
+        result, error = _chat_anthropic(system, messages)
+    return error if error is not None else result
+
+
+# ---------------------------------------------------------------------------
 # Static files
 # ---------------------------------------------------------------------------
 @app.get("/icpac_adm1v3.json")
@@ -271,6 +527,9 @@ async def root():
             "/api/emdat-monthly-risk?type=drought|flood",
             "/api/emdat-month-regions/{event_key}",
             "/api/emdat-event-markdown/{event_key}",
+            "/api/scenarios",
+            "/api/scenarios/{event_id}",
+            "POST /api/scenario-chat",
             "/api/mdx/manifest",
             "/api/mdx/raw/{tab}/{filename}",
             "/api/mdx/media/{path}",

--- a/app/api/scenario-chat/route.ts
+++ b/app/api/scenario-chat/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { apiFetch } from 'app/lib/api-fetch';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const res = await apiFetch('/api/scenario-chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/app/api/scenarios/[eventId]/route.ts
+++ b/app/api/scenarios/[eventId]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { apiFetch } from 'app/lib/api-fetch';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { eventId: string } },
+) {
+  const debrief = request.nextUrl.searchParams.get('debrief') === 'true';
+  const res = await apiFetch(
+    `/api/scenarios/${encodeURIComponent(params.eventId)}${debrief ? '?debrief=true' : ''}`,
+  );
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/app/api/scenarios/route.ts
+++ b/app/api/scenarios/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { apiFetch } from 'app/lib/api-fetch';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const res = await apiFetch('/api/scenarios');
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/app/components/scenario/ScenarioChat.tsx
+++ b/app/components/scenario/ScenarioChat.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ScenarioChatProps {
+  scenarioId: string;
+  round: number;
+  debrief: boolean;
+  bnState?: Record<string, unknown> | null;
+}
+
+/**
+ * LLM explanatory assistant for the scenario simulation (Act II).
+ * Sends the conversation plus simulation position to /api/scenario-chat;
+ * the backend injects round-gated scenario context into the system prompt.
+ */
+export function ScenarioChat({ scenarioId, round, debrief, bnState }: ScenarioChatProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [messages, busy]);
+
+  async function send() {
+    const text = input.trim();
+    if (!text || busy) return;
+    setError(null);
+    setInput('');
+    const history = messages;
+    setMessages((m) => [...m, { role: 'user', content: text }]);
+    setBusy(true);
+    try {
+      const res = await fetch('/api/scenario-chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          scenario_id: scenarioId,
+          round,
+          debrief,
+          message: text,
+          history,
+          bn_state: bnState ?? null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? `Request failed (${res.status})`);
+        return;
+      }
+      setMessages((m) => [...m, { role: 'assistant', content: data.reply }]);
+    } catch {
+      setError('Could not reach the assistant — is the API server running?');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const suggestions = [
+    'What does this evidence tell us about the risk?',
+    'Explain hard vs soft vs virtual evidence',
+    'What additional evidence would improve the decision?',
+  ];
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        border: '1px solid #dfe1e2',
+        borderRadius: 8,
+        background: '#fff',
+        height: 520,
+      }}
+    >
+      <div
+        style={{
+          padding: '0.6rem 1rem',
+          borderBottom: '1px solid #dfe1e2',
+          fontWeight: 600,
+          fontSize: 14,
+        }}
+      >
+        Assistant
+        <span style={{ fontWeight: 400, color: '#71767a', marginLeft: 8 }}>
+          {debrief ? 'debrief mode' : `round ${round} context`}
+        </span>
+      </div>
+
+      <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', padding: '0.75rem 1rem' }}>
+        {messages.length === 0 && (
+          <div style={{ color: '#71767a', fontSize: 14 }}>
+            <p style={{ marginTop: 0 }}>
+              Ask about the evidence cards, the Bayesian Network, uncertainty, or what the
+              current signals mean for DOC decisions.
+            </p>
+            {suggestions.map((s) => (
+              <button
+                key={s}
+                onClick={() => setInput(s)}
+                style={{
+                  display: 'block',
+                  margin: '0.35rem 0',
+                  padding: '0.35rem 0.6rem',
+                  border: '1px solid #dfe1e2',
+                  borderRadius: 16,
+                  background: '#f9f9f9',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  textAlign: 'left',
+                }}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            style={{
+              margin: '0.5rem 0',
+              display: 'flex',
+              justifyContent: m.role === 'user' ? 'flex-end' : 'flex-start',
+            }}
+          >
+            <div
+              style={{
+                maxWidth: '85%',
+                padding: '0.5rem 0.75rem',
+                borderRadius: 10,
+                fontSize: 14,
+                whiteSpace: 'pre-wrap',
+                background: m.role === 'user' ? '#005ea2' : '#f0f0f0',
+                color: m.role === 'user' ? '#fff' : '#1b1b1b',
+              }}
+            >
+              {m.content}
+            </div>
+          </div>
+        ))}
+        {busy && <div style={{ color: '#71767a', fontSize: 13 }}>Thinking…</div>}
+        {error && <div style={{ color: '#b50909', fontSize: 13 }}>{error}</div>}
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, padding: '0.6rem', borderTop: '1px solid #dfe1e2' }}>
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
+          placeholder='Ask the assistant…'
+          rows={1}
+          style={{
+            flex: 1,
+            resize: 'none',
+            padding: '0.5rem',
+            border: '1px solid #dfe1e2',
+            borderRadius: 6,
+            fontSize: 14,
+            fontFamily: 'inherit',
+          }}
+        />
+        <button
+          onClick={send}
+          disabled={busy || !input.trim()}
+          style={{
+            padding: '0 1rem',
+            border: 'none',
+            borderRadius: 6,
+            background: busy || !input.trim() ? '#c9c9c9' : '#005ea2',
+            color: '#fff',
+            cursor: busy || !input.trim() ? 'default' : 'pointer',
+            fontSize: 14,
+          }}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/scenario/[eventId]/page.tsx
+++ b/app/scenario/[eventId]/page.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { ScenarioChat } from 'app/components/scenario/ScenarioChat';
+
+interface EvidenceCard {
+  id: string;
+  label: string;
+  source?: string;
+  bn_node: string;
+  evidence_type: 'hard' | 'soft' | 'virtual';
+  value_by_date: Record<string, string>;
+  teaching_note?: string;
+}
+
+interface Round {
+  round: number;
+  title: string;
+  cursor_date: string;
+  reveal_evidence: string[];
+  checkpoint: boolean;
+  engine_state?: string;
+}
+
+interface Scenario {
+  event_id: string;
+  title: string;
+  hazard: string;
+  country: string;
+  admin1: string;
+  brief_outcome_free: string;
+  rounds: Round[];
+  evidence_cards: EvidenceCard[];
+  decision: {
+    ladder: string[];
+    checkpoint_prompt: string;
+  };
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  hard: '#1a7f37',
+  soft: '#b45309',
+  virtual: '#6f42c1',
+};
+
+function valueAt(card: EvidenceCard, cursor: string): string | null {
+  const dated = Object.entries(card.value_by_date ?? {})
+    .filter(([d]) => d <= cursor)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return dated.length ? dated[dated.length - 1][1] : null;
+}
+
+export default function ScenarioRunner() {
+  const { eventId } = useParams<{ eventId: string }>();
+  const [scenario, setScenario] = useState<Scenario | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [roundIdx, setRoundIdx] = useState(0); // 0-based index into rounds
+  const [debrief, setDebrief] = useState(false);
+
+  useEffect(() => {
+    if (!eventId) return;
+    fetch(`/api/scenarios/${eventId}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.json()).error ?? 'load failed');
+        return r.json();
+      })
+      .then(setScenario)
+      .catch((e) => setError(String(e.message ?? e)));
+  }, [eventId]);
+
+  const round = scenario?.rounds[roundIdx];
+  const revealed = useMemo(() => {
+    if (!scenario || !round) return [];
+    const ids = scenario.rounds
+      .slice(0, roundIdx + 1)
+      .flatMap((r) => r.reveal_evidence);
+    const byId = new Map(scenario.evidence_cards.map((c) => [c.id, c]));
+    return ids.map((id) => byId.get(id)).filter(Boolean) as EvidenceCard[];
+  }, [scenario, round, roundIdx]);
+
+  if (error) {
+    return (
+      <main style={{ maxWidth: 720, margin: '2rem auto', padding: '0 1rem' }}>
+        <p style={{ color: '#b50909' }}>{error}</p>
+        <Link href='/scenario'>← Back to scenarios</Link>
+      </main>
+    );
+  }
+  if (!scenario || !round) {
+    return <main style={{ padding: '2rem' }}>Loading scenario…</main>;
+  }
+
+  const lastRound = roundIdx === scenario.rounds.length - 1;
+
+  return (
+    <main style={{ maxWidth: 1180, margin: '0 auto', padding: '1.5rem 1rem' }}>
+      <Link href='/scenario' style={{ fontSize: 13 }}>
+        ← All scenarios
+      </Link>
+      <h1 style={{ margin: '0.25rem 0' }}>{scenario.title}</h1>
+      <p style={{ color: '#555', marginTop: 0 }}>{scenario.brief_outcome_free}</p>
+
+      {/* Round stepper */}
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', margin: '1rem 0' }}>
+        {scenario.rounds.map((r, i) => (
+          <button
+            key={r.round}
+            onClick={() => {
+              setRoundIdx(i);
+              if (i < scenario.rounds.length - 1) setDebrief(false);
+            }}
+            style={{
+              padding: '0.4rem 0.8rem',
+              borderRadius: 20,
+              border: '1px solid',
+              borderColor: i === roundIdx ? '#005ea2' : '#dfe1e2',
+              background: i === roundIdx ? '#005ea2' : i < roundIdx ? '#e7f2f9' : '#fff',
+              color: i === roundIdx ? '#fff' : '#1b1b1b',
+              cursor: 'pointer',
+              fontSize: 13,
+            }}
+          >
+            R{r.round} · {r.cursor_date}
+          </button>
+        ))}
+        <button
+          onClick={() => {
+            setRoundIdx(scenario.rounds.length - 1);
+            setDebrief(true);
+          }}
+          disabled={!lastRound && !debrief}
+          title={lastRound ? '' : 'Reach the final round first'}
+          style={{
+            padding: '0.4rem 0.8rem',
+            borderRadius: 20,
+            border: '1px solid',
+            borderColor: debrief ? '#6f42c1' : '#dfe1e2',
+            background: debrief ? '#6f42c1' : '#fff',
+            color: debrief ? '#fff' : lastRound ? '#1b1b1b' : '#a9aeb1',
+            cursor: lastRound ? 'pointer' : 'default',
+            fontSize: 13,
+          }}
+        >
+          Debrief
+        </button>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 380px', gap: '1.25rem' }}>
+        <div>
+          {/* Current round panel */}
+          <div
+            style={{
+              border: '1px solid #dfe1e2',
+              borderRadius: 8,
+              padding: '1rem',
+              background: '#fff',
+              marginBottom: '1rem',
+            }}
+          >
+            <div style={{ fontSize: 12, color: '#71767a' }}>
+              Simulation cursor: <strong>{round.cursor_date}</strong>
+            </div>
+            <h2 style={{ margin: '0.25rem 0', fontSize: 18 }}>{round.title}</h2>
+            {round.engine_state && (
+              <p style={{ margin: '0.25rem 0', fontSize: 14, color: '#555' }}>
+                {round.engine_state}
+              </p>
+            )}
+            {round.checkpoint && (
+              <div
+                style={{
+                  marginTop: '0.75rem',
+                  padding: '0.75rem',
+                  borderLeft: '4px solid #005ea2',
+                  background: '#e7f2f9',
+                  fontSize: 14,
+                }}
+              >
+                <strong>Decision checkpoint.</strong> {scenario.decision.checkpoint_prompt}
+                <div style={{ marginTop: 6, fontSize: 13, color: '#555' }}>
+                  Ladder: {scenario.decision.ladder.join(' → ')}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Evidence cards */}
+          <h3 style={{ fontSize: 15, margin: '0 0 0.5rem' }}>
+            Evidence revealed ({revealed.length})
+          </h3>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+              gap: '0.75rem',
+            }}
+          >
+            {revealed.map((card) => {
+              const v = valueAt(card, round.cursor_date);
+              return (
+                <div
+                  key={card.id}
+                  style={{
+                    border: '1px solid #dfe1e2',
+                    borderRadius: 8,
+                    padding: '0.75rem',
+                    background: '#fff',
+                    fontSize: 13,
+                  }}
+                >
+                  <span
+                    style={{
+                      display: 'inline-block',
+                      fontSize: 11,
+                      textTransform: 'uppercase',
+                      letterSpacing: 0.5,
+                      color: '#fff',
+                      background: TYPE_COLORS[card.evidence_type] ?? '#555',
+                      borderRadius: 4,
+                      padding: '1px 6px',
+                      marginBottom: 6,
+                    }}
+                  >
+                    {card.evidence_type}
+                  </span>
+                  <div style={{ fontWeight: 600 }}>{card.label}</div>
+                  <div style={{ color: '#71767a', marginTop: 2 }}>
+                    BN node: <code>{card.bn_node}</code>
+                  </div>
+                  {v && (
+                    <div style={{ marginTop: 6 }}>
+                      Value at {round.cursor_date}: <strong>{v}</strong>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          <div style={{ marginTop: '1rem', display: 'flex', gap: 8 }}>
+            {roundIdx > 0 && (
+              <button
+                onClick={() => setRoundIdx(roundIdx - 1)}
+                style={{
+                  padding: '0.5rem 1rem',
+                  borderRadius: 6,
+                  border: '1px solid #dfe1e2',
+                  background: '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                ← Previous round
+              </button>
+            )}
+            {!lastRound && (
+              <button
+                onClick={() => setRoundIdx(roundIdx + 1)}
+                style={{
+                  padding: '0.5rem 1rem',
+                  borderRadius: 6,
+                  border: 'none',
+                  background: '#005ea2',
+                  color: '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                Advance to round {scenario.rounds[roundIdx + 1].round} →
+              </button>
+            )}
+            {lastRound && !debrief && (
+              <button
+                onClick={() => setDebrief(true)}
+                style={{
+                  padding: '0.5rem 1rem',
+                  borderRadius: 6,
+                  border: 'none',
+                  background: '#6f42c1',
+                  color: '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                Open debrief →
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Chat assistant */}
+        <ScenarioChat
+          scenarioId={scenario.event_id}
+          round={round.round}
+          debrief={debrief}
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/scenario/page.tsx
+++ b/app/scenario/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface ScenarioSummary {
+  event_id: string;
+  title: string;
+  hazard: string;
+  country: string;
+  forecastability: string;
+}
+
+export default function ScenarioLauncher() {
+  const [scenarios, setScenarios] = useState<ScenarioSummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/scenarios')
+      .then((r) => r.json())
+      .then((d) => setScenarios(d.scenarios ?? []))
+      .catch(() => setError('Could not load scenarios'));
+  }, []);
+
+  return (
+    <main style={{ maxWidth: 960, margin: '0 auto', padding: '2rem 1rem' }}>
+      <h1 style={{ marginBottom: '0.25rem' }}>Scenario Simulation</h1>
+      <p style={{ color: '#555', marginBottom: '1.5rem' }}>
+        From Forecast to Action — interactive DOC decision exercises built on
+        historical East African drought and flood events.
+      </p>
+      {error && <p style={{ color: '#b50909' }}>{error}</p>}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+          gap: '1rem',
+        }}
+      >
+        {scenarios.map((sc) => (
+          <Link
+            key={sc.event_id}
+            href={`/scenario/${sc.event_id}`}
+            style={{
+              border: '1px solid #dfe1e2',
+              borderRadius: 8,
+              padding: '1rem',
+              textDecoration: 'none',
+              color: 'inherit',
+              background: '#fff',
+            }}
+          >
+            <div
+              style={{
+                fontSize: 12,
+                textTransform: 'uppercase',
+                letterSpacing: 0.5,
+                color: sc.hazard === 'flood' ? '#0050d8' : '#b45309',
+                marginBottom: 4,
+              }}
+            >
+              {sc.hazard} · {sc.country}
+            </div>
+            <div style={{ fontWeight: 600 }}>{sc.title}</div>
+            <div style={{ fontSize: 13, color: '#71767a', marginTop: 4 }}>
+              forecastability: {sc.forecastability}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/data/scenarios/burundi_drought_2021.json
+++ b/data/scenarios/burundi_drought_2021.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "burundi_drought_2021",
+  "hazard": "drought",
+  "country": "Burundi",
+  "admin1": "Kirundo",
+  "gid_1": "BDI.10_1",
+  "emdat_event_key": "2021-IBF01-BDI",
+  "title": "Burundi drought — 2021-2022",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Northern Burundi (Kirundo and the semi-arid Bugesera depression). Rain-fed smallholder cropping and livestock with degraded water sources; recurrent dry spells. The previous season underperformed. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2021-07",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2020-07",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2020-07)",
+      "cursor_date": "2020-07",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2021-01)",
+      "cursor_date": "2021-01",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2021-07)",
+      "cursor_date": "2021-07",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-07": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-07": "High",
+        "2021-01": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-01": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-01": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2021-01": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-07": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (cash transfers and rehabilitation of community water sources) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2021-IBF01-BDI",
+    "rk_month": "2021-01",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/djibouti_drought_2022.json
+++ b/data/scenarios/djibouti_drought_2022.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "djibouti_drought_2022",
+  "hazard": "drought",
+  "country": "Djibouti",
+  "admin1": "Dikhil",
+  "gid_1": "DJI.2_1",
+  "emdat_event_key": "2022-9370-DJI",
+  "title": "Djibouti drought — 2022",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Djibouti's arid interior (Dikhil). Mobile pastoralist livelihoods dependent on sparse rangeland and boreholes — among the most water-stressed contexts in the region. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2022-07",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2021-12",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2021-12)",
+      "cursor_date": "2021-12",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2022-06)",
+      "cursor_date": "2022-06",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2022-07)",
+      "cursor_date": "2022-07",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-12": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-12": "High",
+        "2022-06": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-06": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-06": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2022-06": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-07": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (water trucking, fodder support and borehole maintenance) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2022-9370-DJI",
+    "rk_month": "2022-06",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/eritrea_highlands_drought_2021.json
+++ b/data/scenarios/eritrea_highlands_drought_2021.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "eritrea_highlands_drought_2021",
+  "hazard": "drought",
+  "country": "Eritrea",
+  "admin1": "Maekel (Central Highlands)",
+  "gid_1": "ERI.1_1",
+  "emdat_event_key": "2021-IBF03-ERI",
+  "title": "Eritrea Central Highlands drought — 2021-2023",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Eritrea's central highlands (Maekel). Rain-fed cereal cropping and livestock on highland terraces under multi-year rainfall deficits. The previous season underperformed. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2021-07",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2020-07",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2020-07)",
+      "cursor_date": "2020-07",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2021-01)",
+      "cursor_date": "2021-01",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2021-07)",
+      "cursor_date": "2021-07",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-07": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-07": "High",
+        "2021-01": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-01": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-01": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2021-01": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-07": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (seed and fodder support and protection of highland water points) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2021-IBF03-ERI",
+    "rk_month": "2021-01",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/ethiopia_blue_nile_drought_2021.json
+++ b/data/scenarios/ethiopia_blue_nile_drought_2021.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "ethiopia_blue_nile_drought_2021",
+  "hazard": "drought",
+  "country": "Ethiopia",
+  "admin1": "Amhara (Blue Nile headwaters)",
+  "gid_1": "ETH.3_1",
+  "emdat_event_key": "2021-9546-ETH",
+  "title": "Ethiopia Blue Nile Headwaters drought — 2021-2022",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Blue Nile headwaters around Lake Tana (Amhara). Rain-fed agriculture in the headwaters of the Blue Nile; below-normal rains threaten cropping and downstream water. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2022-02",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2020-11",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2020-11)",
+      "cursor_date": "2020-11",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2021-05)",
+      "cursor_date": "2021-05",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2022-02)",
+      "cursor_date": "2022-02",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-11": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-11": "High",
+        "2021-05": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-05": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-05": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2021-05": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-02": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (agricultural input support and water-resource contingency planning) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2021-9546-ETH",
+    "rk_month": "2021-05",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/kenya_asal_drought_2020.json
+++ b/data/scenarios/kenya_asal_drought_2020.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "kenya_asal_drought_2020",
+  "hazard": "drought",
+  "country": "Kenya",
+  "admin1": "Tana River / ASAL",
+  "gid_1": "KEN.40_1",
+  "emdat_event_key": "2020-9609-KEN",
+  "title": "Kenya ASAL drought — 2020-2023",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Kenya ASAL counties (Tana River and the wider arid/semi-arid lands). Pastoralist livelihoods, rain-fed cropping and rangeland water sources are exposed after a below-average previous season. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2022-12",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2020-06",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2020-06)",
+      "cursor_date": "2020-06",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2020-12)",
+      "cursor_date": "2020-12",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2022-12)",
+      "cursor_date": "2022-12",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-06": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-06": "High",
+        "2020-12": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-12": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-12": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2020-12": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-12": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (water trucking pre-position and livestock destocking support) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2020-9609-KEN",
+    "rk_month": "2020-12",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/nairobi_flood_2026.json
+++ b/data/scenarios/nairobi_flood_2026.json
@@ -1,0 +1,171 @@
+{
+  "event_id": "nairobi_flood_2026",
+  "hazard": "flood",
+  "country": "Kenya",
+  "admin1": "Nairobi",
+  "gid_1": "KEN.30_1",
+  "emdat_event_key": "2024-0247-KEN",
+  "title": "Nairobi River flash flood — March 2026",
+  "forecastability": "tail",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "date",
+      "calendar": "/api/ibf-flood-calendar",
+      "regions": "/api/ibf-flood-regions/{date}",
+      "dag": "/api/bn-dag/{date}"
+    },
+    "hazard": {
+      "type": "rim2d",
+      "asset_url": "https://huggingface.co/datasets/E4DRR/rim2d-simulations/resolve/main/nairobi_2026-03-06/preview.gif",
+      "caption": "RIM2D inundation footprint — Nairobi, 6 Mar 2026 (illustrative hazard extent)",
+      "validation": "illustrative"
+    }
+  },
+  "brief_outcome_free": "Nairobi admin-1, early March long-rains onset. Dense informal settlements along the Nairobi/Mathare/Ngong river corridors are exposed to flash flooding. Ground is already wet from late-February rain. You are the DOC duty analyst on Mar 1.",
+  "peak": {
+    "date": "2026-03-06",
+    "description": "Nairobi River flash flood overnight 6-7 Mar",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2026-03-01",
+    "offset_label": "T-5 days"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early monitoring (T-5)",
+      "cursor_date": "2026-03-01",
+      "reveal_evidence": [
+        "antecedent",
+        "exceedance"
+      ],
+      "checkpoint": false,
+      "engine_state": "Moderate risk / Evaluate (Yellow) — saturated ground, mean forecast still modest"
+    },
+    {
+      "round": 2,
+      "title": "Forecast escalation (T-2)",
+      "cursor_date": "2026-03-04",
+      "reveal_evidence": [
+        "tail_risk",
+        "spatial",
+        "dbn_carry"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_tail_risk",
+        "interpret_mean_vs_tail",
+        "doc_action_at_T2"
+      ],
+      "engine_state": "Moderate risk / Assess (Orange) — tail ratio 1.11 crosses 2-yr RP, 2-day lead"
+    },
+    {
+      "round": 3,
+      "title": "Observed confirmation (T0)",
+      "cursor_date": "2026-03-06",
+      "reveal_evidence": [
+        "observed_onset"
+      ],
+      "checkpoint": true,
+      "engine_state": "High risk / Actionable_Risk (Red) — flood onset; DBN carries the Mar 4 signal forward"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "antecedent",
+      "label": "7-day antecedent rainfall (IMERG)",
+      "source": "IMERG HH icechunk, 7-day sum",
+      "bn_node": "antecedent_rainfall",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2026-03-01": "135 mm -> Saturated"
+      }
+    },
+    {
+      "id": "exceedance",
+      "label": "Ensemble-mean exceedance prob (ECMWF P_heavy)",
+      "source": "ECMWF 51-member TP, P(any member >= 2-yr RP), mean",
+      "bn_node": "exceedance_prob",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2026-03-01": "Low",
+        "2026-03-04": "Low-Medium"
+      },
+      "teaching_note": "The MEAN looks benign. Do not stop here."
+    },
+    {
+      "id": "tail_risk",
+      "label": "Ensemble-max / 2-yr RP, pixel p95",
+      "source": "p95 of (ens_max / 2-yr RP) per pixel",
+      "bn_node": "tail_risk",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2026-03-04": "ratio 1.11 -> tail crosses threshold"
+      },
+      "teaching_note": "Mean ~18 mm vs worst member 131 mm. Only the tail fires. THIS is the signal a mean-threshold system misses."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of heavy-rain pixels",
+      "bn_node": "spatial_coverage",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2026-03-04": "Localized-Moderate"
+      }
+    },
+    {
+      "id": "dbn_carry",
+      "label": "Yesterday's risk posterior carried forward (DBN, alpha=0.6)",
+      "source": "run_dbn_sequence R_obs virtual-evidence channel",
+      "bn_node": "R_obs",
+      "evidence_type": "virtual",
+      "teaching_note": "Temporal coupling = virtual evidence. It is why Mar 6 stays elevated."
+    },
+    {
+      "id": "observed_onset",
+      "label": "Observed rainfall / river response",
+      "bn_node": "antecedent_rainfall",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2026-03-06": "onset confirmed"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "At T-2 (Mar 4) the ensemble MEAN is benign but the tail crosses the 2-yr RP. What DOC level do you set, and why? A 'Watch + 24h re-check + note the tail uncertainty' is a strong answer."
+  },
+  "counterfactual": {
+    "prompt": "What if a precautionary no-regret action (alert river-corridor focal points, pre-position) were taken at T-2 on the tail signal?",
+    "virtual_evidence_node": "R_obs",
+    "narrative": "Acting on the 2-day-lead tail signal — even under a benign ensemble mean — is exactly the lead time CRMA's tail_risk node exists to surface. The counterfactual illustrates loss reduction without claiming certainty."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2024-0247-KEN",
+    "rk_month": "2024-04",
+    "loss_note_2026": "Replay/hazard are the 2026 event (>=108 deaths across Kenya by month-end); RK MDX key 2024-0247-KEN is the 2024 storyline. Confirm which loss text the debrief should show (see IMPLEMENTATION_PLAN.md open item 3).",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "weight_you_got_wrong",
+      "would_no_regret_have_helped"
+    ]
+  }
+}

--- a/data/scenarios/rwanda_akagera_drought_2016.json
+++ b/data/scenarios/rwanda_akagera_drought_2016.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "rwanda_akagera_drought_2016",
+  "hazard": "drought",
+  "country": "Rwanda",
+  "admin1": "Eastern Province (Akagera)",
+  "gid_1": "RWA.3_1",
+  "emdat_event_key": "2016-IBF06-RWA",
+  "title": "Rwanda Eastern Province (Akagera) drought — 2016-2017",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Rwanda's drier Eastern Province (Akagera basin) — the country's most drought-prone zone. Rain-fed cropping and livestock; the previous season underperformed. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2016-07",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2015-07",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2015-07)",
+      "cursor_date": "2015-07",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2016-01)",
+      "cursor_date": "2016-01",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2016-07)",
+      "cursor_date": "2016-07",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2015-07": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2015-07": "High",
+        "2016-01": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2016-01": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2016-01": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2016-01": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2016-07": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (water-harvesting/irrigation support and livestock destocking) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2016-IBF06-RWA",
+    "rk_month": "2016-01",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/somalia_southcentral_drought_2020.json
+++ b/data/scenarios/somalia_southcentral_drought_2020.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "somalia_southcentral_drought_2020",
+  "hazard": "drought",
+  "country": "Somalia",
+  "admin1": "Bay",
+  "gid_1": "SOM.5_1",
+  "emdat_event_key": "2020-9609-SOM",
+  "title": "Somalia South-Central drought — 2020-2023",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "South-central Somalia (Bay region). Agropastoral livelihoods, chronic food insecurity, and a history of consecutive failed rains driving severe drought. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2022-12",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2020-09",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2020-09)",
+      "cursor_date": "2020-09",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2021-03)",
+      "cursor_date": "2021-03",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2022-12)",
+      "cursor_date": "2022-12",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-09": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-09": "High",
+        "2021-03": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-03": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-03": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2021-03": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-12": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (anticipatory cash, water trucking and supplementary feeding) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2020-9609-SOM",
+    "rk_month": "2020-03",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/south_sudan_upper_nile_drought_2021.json
+++ b/data/scenarios/south_sudan_upper_nile_drought_2021.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "south_sudan_upper_nile_drought_2021",
+  "hazard": "drought",
+  "country": "South Sudan",
+  "admin1": "Upper Nile",
+  "gid_1": "SSD.7_1",
+  "emdat_event_key": "2021-9639-SSD",
+  "title": "South Sudan Upper Nile drought — 2021-2023",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Upper Nile, South Sudan. Agropastoral and flood-recession livelihoods under compounding climate and conflict stress; below-normal rains deepen food insecurity. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2022-11",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2020-12",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2020-12)",
+      "cursor_date": "2020-12",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2021-06)",
+      "cursor_date": "2021-06",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2022-11)",
+      "cursor_date": "2022-11",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-12": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2020-12": "High",
+        "2021-06": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-06": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-06": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2021-06": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-11": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (anticipatory food/cash support and water-source protection) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2021-9639-SSD",
+    "rk_month": "2021-01",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/sudan_eastern_drought_2022.json
+++ b/data/scenarios/sudan_eastern_drought_2022.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "sudan_eastern_drought_2022",
+  "hazard": "drought",
+  "country": "Sudan",
+  "admin1": "Kassala",
+  "gid_1": "SDN.6_1",
+  "emdat_event_key": "2022-9788-SDN",
+  "title": "Sudan Eastern States drought — 2022",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Eastern Sudan (Kassala). Rain-fed sorghum/millet and pastoralism on the Sahelian margin; erratic rains and degraded rangeland. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2022-11",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2021-12",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2021-12)",
+      "cursor_date": "2021-12",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2022-06)",
+      "cursor_date": "2022-06",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2022-11)",
+      "cursor_date": "2022-11",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-12": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-12": "High",
+        "2022-06": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-06": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-06": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2022-06": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-11": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (agricultural input support, water trucking and fodder reserves) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2022-9788-SDN",
+    "rk_month": "2022-01",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/tanzania_kagera_drought_2021.json
+++ b/data/scenarios/tanzania_kagera_drought_2021.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "tanzania_kagera_drought_2021",
+  "hazard": "drought",
+  "country": "Tanzania",
+  "admin1": "Kagera",
+  "gid_1": "TZA.6_1",
+  "emdat_event_key": "2021-9848-TZA",
+  "title": "Tanzania Kagera drought — 2021-2022",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Kagera region, north-western Tanzania. Banana/coffee and rain-fed cropping with livestock; below-normal rains stress crops and water sources. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2022-12",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2021-05",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2021-05)",
+      "cursor_date": "2021-05",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2021-11)",
+      "cursor_date": "2021-11",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2022-12)",
+      "cursor_date": "2022-12",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-05": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-05": "High",
+        "2021-11": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-11": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2021-11": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2021-11": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-12": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (agricultural input support and water-source rehabilitation) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2021-9848-TZA",
+    "rk_month": "2021-11",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/data/scenarios/uganda_karamoja_drought_2022.json
+++ b/data/scenarios/uganda_karamoja_drought_2022.json
@@ -1,0 +1,165 @@
+{
+  "event_id": "uganda_karamoja_drought_2022",
+  "hazard": "drought",
+  "country": "Uganda",
+  "admin1": "Karamoja (Moroto)",
+  "gid_1": "UGA.40_1",
+  "emdat_event_key": "2022-9436-UGA",
+  "title": "Uganda Karamoja drought — 2022",
+  "forecastability": "strong",
+  "mode_defaults": {
+    "hindsight": "off",
+    "duration_min": 60
+  },
+  "layers": {
+    "risk_monitoring": {
+      "key_field": "init",
+      "calendar": "/api/ibf-drought-calendar",
+      "regions": "/api/ibf-drought-regions/{init}",
+      "dag": "/api/drought-bn-dag/{init}"
+    }
+  },
+  "brief_outcome_free": "Karamoja sub-region, north-eastern Uganda (anchored on Moroto; spans Kotido and Nakapiripirit). Semi-arid agro-pastoralist livelihoods, chronically food-insecure, dependent on a single short season. You are the DOC drought analyst.",
+  "peak": {
+    "date": "2022-12",
+    "description": "Recorded drought extent / peak — see the Risk Knowledge storyline for loss & damage.",
+    "hidden_until": "debrief"
+  },
+  "simulation_start": {
+    "cursor_date": "2022-01",
+    "offset_label": "T-6 months (lead)"
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "title": "Early signal — lead (2022-01)",
+      "cursor_date": "2022-01",
+      "reveal_evidence": [
+        "current_spi3",
+        "forecast_deficit"
+      ],
+      "checkpoint": false,
+      "engine_state": "SEAS5 forecast deficit emerging ~6 months ahead of the event window; current SPI-3 below normal"
+    },
+    {
+      "round": 2,
+      "title": "Onset — event window begins (2022-07)",
+      "cursor_date": "2022-07",
+      "reveal_evidence": [
+        "spatial",
+        "trend",
+        "cdi"
+      ],
+      "checkpoint": true,
+      "quiz": [
+        "classify_cdi_virtual",
+        "classify_forecast_soft",
+        "doc_action_strong_signal"
+      ],
+      "engine_state": "Deficit confirmed; CDI virtual-evidence sharpens the posterior; DOC escalation window opens"
+    },
+    {
+      "round": 3,
+      "title": "Peak / event duration (2022-12)",
+      "cursor_date": "2022-12",
+      "reveal_evidence": [
+        "current_spi3_confirm"
+      ],
+      "checkpoint": true,
+      "engine_state": "Sustained deficit through the recorded event duration"
+    }
+  ],
+  "evidence_cards": [
+    {
+      "id": "current_spi3",
+      "label": "Observed SPI-3 ending at init (ERA5)",
+      "source": "ERA5 SPI zarr",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-01": "Mild-Moderate drought"
+      }
+    },
+    {
+      "id": "forecast_deficit",
+      "label": "SEAS5 forecast deficit probability (vs ERA5 RP threshold)",
+      "source": "SEAS5 SPI-3 25-member vs era5_ecmwf_rp_icechunk 5-yr",
+      "bn_node": "def",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-01": "High",
+        "2022-07": "High"
+      },
+      "teaching_note": "Slow-onset signal is STRONG and visible ~6 months ahead — long lead time for anticipatory action."
+    },
+    {
+      "id": "spatial",
+      "label": "Spatial coverage of RP exceedance",
+      "bn_node": "spa",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-07": "Widespread"
+      }
+    },
+    {
+      "id": "trend",
+      "label": "SPI-3 trend (6-month slope)",
+      "bn_node": "trn",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-07": "Deteriorating"
+      }
+    },
+    {
+      "id": "cdi",
+      "label": "Combined Drought Indicator (JRC 14-class)",
+      "source": "ICPAC EADW / recompute; 14x5 noisy-likelihood applied to risk posterior",
+      "bn_node": "cdi_class",
+      "evidence_type": "virtual",
+      "value_by_date": {
+        "2022-07": "Alert (7-10)"
+      },
+      "teaching_note": "CDI is NOT a BN parent. It updates the risk posterior multiplicatively = Pearl virtual evidence."
+    },
+    {
+      "id": "current_spi3_confirm",
+      "label": "Observed SPI-3 through the event (ERA5)",
+      "bn_node": "cur",
+      "evidence_type": "soft",
+      "value_by_date": {
+        "2022-12": "Severe drought"
+      }
+    }
+  ],
+  "decision": {
+    "ladder": [
+      "Monitor",
+      "Watch",
+      "Warning",
+      "Emergency Coordination"
+    ],
+    "crma_mapping": {
+      "Monitor": "Monitor",
+      "Watch": "Evaluate",
+      "Warning": "Assess",
+      "Emergency Coordination": "Actionable_Risk"
+    },
+    "require_uncertainty_note": true,
+    "allow_no_regret": true,
+    "checkpoint_prompt": "Forecast deficit and CDI agree months ahead of the event window. This is a STRONG, early signal. What DOC level do you set, and what anticipatory action does the ~6-month lead justify?"
+  },
+  "counterfactual": {
+    "prompt": "What if anticipatory action (cash transfers, water trucking and supplementary feeding) were triggered at the lead round on the strong forecast signal?",
+    "virtual_evidence_node": "cdi_class",
+    "narrative": "Slow-onset droughts give long lead. The counterfactual shows the loss-reduction value of acting on a confident seasonal signal rather than waiting for impact confirmation."
+  },
+  "debrief": {
+    "loss_markdown": "/api/emdat-event-markdown/2022-9436-UGA",
+    "rk_month": "2022-07",
+    "reconstruction_quiz": [
+      "which_signal_preceded",
+      "did_we_act_early_enough",
+      "value_of_lead_time"
+    ]
+  }
+}

--- a/docs/SCENARIO_CHAT_INTEGRATION.md
+++ b/docs/SCENARIO_CHAT_INTEGRATION.md
@@ -1,0 +1,80 @@
+# Scenario LLM Chat — Integration Guide
+
+LLM explanatory assistant for the scenario simulation (Act II of the
+"From Forecast to Action" exercise). Participants chat with an assistant that
+has round-gated scenario context: it sees only the evidence revealed up to the
+current round, never reveals the historical outcome before debrief, and stays
+Socratic about DOC decisions.
+
+## What this branch adds
+
+| Piece | Path | Notes |
+|---|---|---|
+| Chat endpoint | `app.py` → `POST /api/scenario-chat` | Builds the system prompt from the scenario JSON, calls the LLM |
+| Scenario endpoints | `app.py` → `GET /api/scenarios`, `GET /api/scenarios/{event_id}` | Forward view strips `peak`/`debrief`/`counterfactual` so the outcome cannot leak to the browser |
+| Scenario data | `data/scenarios/*.json` | Copied from `cmra/scenario-sim/scenarios/` — drop newer/extra scenario JSONs (e.g. the 11 flood events) in here, no code change needed |
+| Chat UI | `app/components/scenario/ScenarioChat.tsx` | Self-contained client component — **this is the piece to integrate into the real ScenarioRunner** |
+| Next route handlers | `app/api/scenario-chat/`, `app/api/scenarios/` | Proxy to crma-api with the existing `apiFetch` identity-token pattern |
+| Dev stand-in pages | `app/scenario/page.tsx`, `app/scenario/[eventId]/page.tsx` | **Placeholder only.** Built because the deployed ScenarioRunner source is not in this branch. Replace/merge with the real ScenarioRunner; keep only `ScenarioChat` |
+
+## Integrating ScenarioChat into the real ScenarioRunner
+
+```tsx
+import { ScenarioChat } from 'app/components/scenario/ScenarioChat';
+
+<ScenarioChat
+  scenarioId={scenario.event_id}  // e.g. "kenya_asal_drought_2020"
+  round={currentRound}            // 1-based round number — gates which evidence the LLM sees
+  debrief={isDebrief}             // true after the exercise → unlocks outcome + counterfactual
+  bnState={posterior}             // OPTIONAL: BN posterior snapshot from the DAG panel,
+                                  // injected into the prompt so the LLM can discuss it
+/>
+```
+
+The component manages its own message history and POSTs to `/api/scenario-chat`
+with `{scenario_id, round, debrief, message, history, bn_state}`. The backend
+is stateless — all context is rebuilt per request from the scenario JSON.
+
+## LLM provider — no API key required, but supported
+
+The backend auto-selects (`SCENARIO_LLM_PROVIDER=auto`, the default):
+
+- `ANTHROPIC_API_KEY` set → **Anthropic API** (`claude-opus-4-8`,
+  override with `SCENARIO_CHAT_MODEL`). Recommended for the conference
+  session and the public site — set the key via GCP Secret Manager on the
+  crma-api Cloud Run service.
+- No key → **local Ollama** (`OLLAMA_BASE_URL`, default `http://localhost:11434`;
+  `OLLAMA_MODEL`, default `llama3.2:3b`). Useful for offline workshops and
+  keyless local dev. Small models (≤3B) plumb fine but garble Bayesian
+  concepts — use ≥7B (e.g. `qwen2.5:7b`) or the API for real sessions.
+
+Force a provider with `SCENARIO_LLM_PROVIDER=anthropic|ollama`.
+
+## Local dev
+
+```bash
+# Backend (needs: pip install fastapi uvicorn pandas pyarrow anthropic)
+uvicorn app:app --port 8000          # any port; match NEXT_PUBLIC_API_BASE_URL
+
+# Optional local LLM
+ollama serve & ollama pull llama3.2:3b
+
+# Frontend
+yarn install && yarn dev
+# open http://localhost:3000/scenario
+```
+
+## Deploy checklist (crma-api)
+
+1. Add `anthropic` to the API image requirements.
+2. Include `data/scenarios/` in the image (or set `SCENARIOS_DIR`).
+3. Set `ANTHROPIC_API_KEY` from Secret Manager (or `OLLAMA_*` if self-hosting a model).
+4. Frontend ships via the normal `_build_fe.sh` — route handlers reuse `apiFetch`.
+
+## Prompt behaviour (enforced server-side, see `_build_chat_system_prompt`)
+
+- Only evidence from rounds ≤ current round, values at the simulation cursor.
+- Hard / soft / virtual evidence typology + teaching notes woven in.
+- Forward rounds: outcome, peak, losses strictly withheld.
+- Debrief: outcome + counterfactual unlocked, forensic-reconstruction guidance.
+- Never prescribes a DOC level — asks what the evidence and posterior support.


### PR DESCRIPTION
Adds an LLM chat assistant to the scenario simulation. Nothing else changed.

- `POST /api/scenario-chat` — chat with round-gated scenario context (outcome hidden until debrief)
- `ScenarioChat.tsx` — drop-in component for the ScenarioRunner (`scenarioId`, `round`, `debrief`, optional `bnState`)
- Works without an API key (local Ollama); uses the Anthropic API when `ANTHROPIC_API_KEY` is set

Integration notes: `docs/SCENARIO_CHAT_INTEGRATION.md`